### PR TITLE
Exclude PackAsTool projects from PKG-02

### DIFF
--- a/PanoramicData.NugetManagement.Test/PackagingRuleScopeTests.cs
+++ b/PanoramicData.NugetManagement.Test/PackagingRuleScopeTests.cs
@@ -13,6 +13,13 @@ public class PackagingRuleScopeTests(ITestOutputHelper output) : TestWithOutput(
 	private const string _publishedButBare =
 		"<Project><PropertyGroup><GeneratePackageOnBuild>true</GeneratePackageOnBuild></PropertyGroup></Project>";
 
+	private const string _toolProject =
+		"<Project><PropertyGroup><PackageId>Acme.Tool</PackageId><PackAsTool>true</PackAsTool>"
+		+ "<ToolCommandName>acme</ToolCommandName><OutputType>Exe</OutputType></PropertyGroup></Project>";
+
+	private const string _ordinaryPackage =
+		"<Project><PropertyGroup><PackageId>Acme.Lib</PackageId></PropertyGroup></Project>";
+
 	private const string _sampleApp =
 		"<Project><PropertyGroup><OutputType>Exe</OutputType><IsPackable>false</IsPackable></PropertyGroup></Project>";
 
@@ -139,6 +146,54 @@ public class PackagingRuleScopeTests(ITestOutputHelper output) : TestWithOutput(
 		var result = await GetRule("PKG-10").EvaluateAsync(context, CancellationToken.None);
 
 		result.Passed.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task PKG02_ShouldNotDemandGeneratePackageOnBuild_OfAToolProject()
+	{
+		// Issue 71: a tool project is packed via publish. GeneratePackageOnBuild makes packing run
+		// during Build, before that publish output exists, so dotnet pack fails with MSB3030 and
+		// produces no package at all. IsPackableProject counts PackAsTool as evidence a project is
+		// published, so without this exclusion the rule pulls tool projects in and then breaks them.
+		var context = CreateContext("Acme.Tool", new Dictionary<string, string>
+		{
+			["Acme.Tool/Acme.Tool.csproj"] = _toolProject
+		});
+
+		var result = await GetRule("PKG-02").EvaluateAsync(context, CancellationToken.None);
+
+		result.Passed.Should().BeTrue("a tool project must not be told to enable GeneratePackageOnBuild");
+	}
+
+	[Fact]
+	public async Task PKG02_ShouldStillDemandGeneratePackageOnBuild_OfAnOrdinaryPackageProject()
+	{
+		// Guards the exclusion above against over-reaching.
+		var context = CreateContext("Acme.Lib", new Dictionary<string, string>
+		{
+			["Acme.Lib/Acme.Lib.csproj"] = _ordinaryPackage
+		});
+
+		var result = await GetRule("PKG-02").EvaluateAsync(context, CancellationToken.None);
+
+		result.Passed.Should().BeFalse();
+		result.Message.Should().Contain("Acme.Lib");
+	}
+
+	[Fact]
+	public async Task PKG02_ShouldFlagOnlyTheNonToolProject_InAMixedRepository()
+	{
+		var context = CreateContext("Acme.Suite", new Dictionary<string, string>
+		{
+			["Tool/Acme.Tool.csproj"] = _toolProject,
+			["Lib/Acme.Lib.csproj"] = _ordinaryPackage
+		});
+
+		var result = await GetRule("PKG-02").EvaluateAsync(context, CancellationToken.None);
+
+		result.Passed.Should().BeFalse();
+		result.Message.Should().Contain("Acme.Lib.csproj");
+		result.Message.Should().NotContain("Acme.Tool.csproj");
 	}
 
 	private static IRule GetRule(string ruleId)

--- a/PanoramicData.NugetManagement/Rules/NuGetHygiene/GeneratePackageOnBuildRule.cs
+++ b/PanoramicData.NugetManagement/Rules/NuGetHygiene/GeneratePackageOnBuildRule.cs
@@ -4,6 +4,11 @@ namespace PanoramicData.NugetManagement.Rules;
 
 /// <summary>
 /// Checks that GeneratePackageOnBuild is enabled in packable projects.
+/// <para>
+/// Projects that set <c>PackAsTool</c> are excluded. Packing a tool runs a publish, and
+/// <c>GeneratePackageOnBuild</c> makes packing run during Build - before that publish output
+/// exists - so enabling it makes <c>dotnet pack</c> fail with MSB3030 and produce no package.
+/// </para>
 /// </summary>
 public class GeneratePackageOnBuildRule : RuleBase
 {
@@ -28,7 +33,18 @@ public class GeneratePackageOnBuildRule : RuleBase
 			return Task.FromResult(notApplicable);
 		}
 
-		var missing = projects
+		// Tool projects are packed via publish; GeneratePackageOnBuild would break their packaging.
+		var applicable = projects
+			.Where(csproj => !HasMsBuildProperty(context.GetFileContent(csproj), "PackAsTool", "true"))
+			.ToList();
+
+		if (applicable.Count == 0)
+		{
+			return Task.FromResult(NotApplicable(
+				"Every published project packs as a .NET tool; GeneratePackageOnBuild does not apply."));
+		}
+
+		var missing = applicable
 			.Where(csproj => !HasMsBuildProperty(context.GetFileContent(csproj), "GeneratePackageOnBuild", "true"))
 			.ToList();
 
@@ -50,6 +66,6 @@ public class GeneratePackageOnBuildRule : RuleBase
 				}));
 		}
 
-		return Task.FromResult(Pass($"All {projects.Count} published project(s) have GeneratePackageOnBuild enabled."));
+		return Task.FromResult(Pass($"All {applicable.Count} published project(s) have GeneratePackageOnBuild enabled."));
 	}
 }


### PR DESCRIPTION
Fixes #71.

## The problem

PKG-02 required `GeneratePackageOnBuild=true` on every packable project. `RepositoryContext.IsPackableProject` counts `PackAsTool=true` as evidence that a project is published — so tool projects were pulled **into** scope and then handed the one setting that breaks their packaging.

The two are incompatible. Packing a tool runs a **publish**; `GeneratePackageOnBuild` makes packing run during **Build**, before that publish output exists, so `dotnet pack` fails with four `MSB3030` errors and produces no package at all.

The failure is easy to miss:

- it fails at *pack*, not build, so an ordinary build stays green and it only surfaces in a publish pipeline
- a populated `bin`/`obj` from an earlier build can mask it, so it presents as an intermittent CI-only fault

## The change

`GeneratePackageOnBuildRule` now excludes projects declaring `PackAsTool`, and returns `NotApplicable` when every published project is a tool.

## Tests

Three added to `PackagingRuleScopeTests`, **verified red before green**. With the rule reverted and the tests in place:

| Test | Rule reverted | Rule fixed |
|---|---|---|
| `ShouldNotDemandGeneratePackageOnBuild_OfAToolProject` | fails | passes |
| `ShouldFlagOnlyTheNonToolProject_InAMixedRepository` | fails | passes |
| `ShouldStillDemandGeneratePackageOnBuild_OfAnOrdinaryPackageProject` | passes | passes |

The third passes in both states **by design** — it guards the exclusion against over-reaching, so it must not depend on the fix. The mixed-repository test is the important one: it asserts the ordinary project is still flagged *and* the tool project is not, so the exclusion cannot silently swallow real findings.

Full class: 17 tests, all passing. Solution builds with no new warnings (the one existing warning is `.Web` reporting that pack-on-build cannot package a non-packable project, which predates this change).

## Checklist

- [x] Code compiles with zero new warnings
- [x] All existing tests pass
- [x] New behaviour has corresponding tests
- [x] XML documentation updated to explain the exclusion
- [x] No Newtonsoft.Json references
- [x] No suppressed warnings

## Worth considering separately

`GeneratePackageOnBuild=true` is arguably questionable for any repository that packs explicitly in CI, since it makes every local build produce a package as a side effect. Requiring a project to be *packable* is sound; requiring it to pack *on every build* is a stronger claim than the standard needs. Not changed here — it would alter the rule's intent rather than fix a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
