### PR TITLE
Verify the build before pushing a remediation

### DIFF
--- a/PanoramicData.NugetManagement.Web/Models/RepoGuardStatus.cs
+++ b/PanoramicData.NugetManagement.Web/Models/RepoGuardStatus.cs
@@ -20,6 +20,13 @@ public enum GuardState
 	/// <summary>Build is failing, but not because of our change (pre-existing) — left untouched.</summary>
 	BuildFailingNotOurs,
 
+	/// <summary>
+	/// The build is failing and we could not establish whether our change caused it, because the
+	/// control build at the last-good commit also failed. Treated as suspicious, not exonerating:
+	/// a remediation that breaks the toolchain fails both builds identically.
+	/// </summary>
+	VerificationInconclusive,
+
 	/// <summary>An error occurred while verifying or rolling back.</summary>
 	Error
 }

--- a/PanoramicData.NugetManagement.Web/Services/DashboardService.cs
+++ b/PanoramicData.NugetManagement.Web/Services/DashboardService.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Options;
 using Octokit;
 using PanoramicData.NugetManagement.Models;
-using PanoramicData.NugetManagement.Rules;
 using PanoramicData.NugetManagement.Services;
 using PanoramicData.NugetManagement.Web.Models;
 using PanoramicData.NugetManagement.Web.Remediations;
@@ -1350,6 +1349,30 @@ public class DashboardService
 						Status = RepoApplyStatus.NothingToDo,
 						Message = "No changes to apply after sync."
 					});
+					continue;
+				}
+
+				// Verify before pushing. The regression guard can only revert *after* a push, which
+				// leaves a live branch broken in the meantime - and it cannot attribute the breakage
+				// at all when a remediation has broken the toolchain, because the control build fails
+				// too. Building here makes a bad remediation cost a skipped repository instead.
+				onOutput?.Invoke($"🔎 Verifying {name} builds before pushing...");
+				var preflight = await _localRepo.BuildWithRestoreAsync(name, onOutput, cancellationToken).ConfigureAwait(false);
+				if (!preflight.Success)
+				{
+					// Same principle as the cancellation path: work that never reached a commit is
+					// undone, so the clone is left as it was found rather than half-remediated.
+					await RevertUncommittedAsync(row, name, onOutput).ConfigureAwait(false);
+					phase = RepoApplyPhase.NotStarted;
+					outcome.Results.Add(new RepoApplyResult
+					{
+						RepositoryFullName = name,
+						// A refusal is a skip, not a failure: nothing was left behind.
+						Status = RepoApplyStatus.Skipped,
+						Message = "Not pushed: the repository does not build after applying the remediation. "
+							+ "The change was reverted locally. This is a bug in the remediation."
+					});
+					onOutput?.Invoke($"⛔ {name}: does not build after applying - not pushed, change reverted.");
 					continue;
 				}
 

--- a/PanoramicData.NugetManagement.Web/Services/RegressionGuardService.cs
+++ b/PanoramicData.NugetManagement.Web/Services/RegressionGuardService.cs
@@ -1,7 +1,5 @@
 using System.Collections.Concurrent;
 using System.Threading.Channels;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using PanoramicData.NugetManagement.Services;
 using PanoramicData.NugetManagement.Web.Models;
 
@@ -97,8 +95,19 @@ public sealed class RegressionGuardService(
 		var parentBuild = await localRepo.BuildAtCommitAsync(repositoryFullName, lastGoodRef, null, cancellationToken).ConfigureAwait(false);
 		if (!parentBuild.Success)
 		{
-			SetStatus(repositoryFullName, GuardState.BuildFailingNotOurs,
-				$"Build is failing, but it was already broken before our {ourCount} commit(s) — left in place for investigation.");
+			// The control build failing does NOT prove the breakage predates us. It is equally
+			// consistent with the toolchain being unavailable, or with a remediation that broke the
+			// build at every commit - pinning global.json to an uninstalled SDK fails HEAD and the
+			// control commit identically. Treating that as exoneration disables the guard exactly
+			// when the damage is worst, so it is reported as inconclusive and left visible.
+			logger.LogWarning(
+				"Regression guard: {Repo} is failing and the control build at {LastGood} also failed; "
+				+ "cannot attribute. Our {Count} commit(s) remain in place and need a human look.",
+				repositoryFullName, lastGoodRef, ourCount);
+			SetStatus(repositoryFullName, GuardState.VerificationInconclusive,
+				$"Build is failing and the control build at {lastGoodRef} also failed, so it could not be "
+				+ $"established whether our {ourCount} commit(s) caused it. They are still in place. "
+				+ "Check the toolchain on this host before assuming the breakage predates them.");
 			return;
 		}
 


### PR DESCRIPTION
Fixes #73. Two changes, both small.

## 1. Verify before pushing

`DashboardService` now builds each repository **after applying** a remediation and **before committing**. If it does not build, the change is reverted locally and the repository is skipped.

```
before:  apply → commit → push → build → maybe revert
after:   apply → build → commit → push
```

A bad remediation now costs a skipped repository instead of a broken branch. The revert reuses the existing helper from the cancellation path, on the principle already stated there — *work that never reached a commit is undone, so the clone is left as it was found rather than half-remediated*.

`RegressionGuardService` is **unchanged as a backstop**. A build that succeeds locally can still fail in CI, so the post-push path still earns its place; it is just no longer the only line of defence.

## 2. A failed control build no longer exonerates

The guard built the last-good commit to confirm our commits were the cause, and treated a failure there as proof the breakage predated us:

```csharp
if (!parentBuild.Success)
{
    SetStatus(..., GuardState.BuildFailingNotOurs,
        "...it was already broken before our N commit(s) — left in place for investigation.");
    return;
}
```

That is not proof of that. It is equally consistent with the toolchain being unavailable, or with a remediation that broke the build at **every** commit. Pinning `global.json` to an SDK the host does not have fails HEAD and the control commit identically, because `rollForward: latestFeature` will not roll down to an installed feature band. The guard then concludes "already broken before our commits", stands down, and reports a state that reads as reassuring — least effective exactly when the damage is worst.

That path now reports a new `GuardState.VerificationInconclusive`, logs a warning, and says plainly that the commits are still in place and the toolchain should be checked before assuming the breakage predates them.

## Tests

**None added, deliberately, and worth flagging rather than passing over.** Both paths are I/O-bound service code with no existing seam: `LocalRepoService` is a concrete dependency of both `DashboardService` and `RegressionGuardService`, so a unit test would require introducing an abstraction — a larger change than this fix, and one better decided separately.

The existing suite passes: **274 of 277**. The 3 failures are `GitHubIntegrationTests` reporting `GitHub:Token is not configured in user secrets`, which fail on any host without that secret and are unrelated to this change.

Incidentally, that class's doc comment says those tests are *"reported as skipped, not failed, on a machine with no GitHub secret configured"* — the behaviour and the comment disagree. Not touched here.

## Checklist

- [x] Code compiles with zero new warnings (the one existing warning is `.Web` reporting pack-on-build cannot package a non-packable project, and predates this change)
- [x] All existing tests pass, bar the pre-existing secret-dependent ones above
- [x] XML documentation on the new enum member
- [x] No Newtonsoft.Json references
- [x] No suppressed warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
