### PR TITLE
Scope CPM-02 to governed projects, and pin the SDK band floor

### DIFF
--- a/PanoramicData.NugetManagement.Test/CpmScopeTests.cs
+++ b/PanoramicData.NugetManagement.Test/CpmScopeTests.cs
@@ -1,0 +1,104 @@
+using PanoramicData.NugetManagement.Models;
+using PanoramicData.NugetManagement.Rules;
+using PanoramicData.NugetManagement.Services;
+
+namespace PanoramicData.NugetManagement.Test;
+
+/// <summary>
+/// Tests that CPM-02 follows the projects central package management actually governs. CPM is
+/// resolved per directory, so a project under an opt-out gets its versions from its inline
+/// attributes and nowhere else - issue 75, where removing them left the project unable to restore.
+/// </summary>
+public class CpmScopeTests(ITestOutputHelper output) : TestWithOutput(output)
+{
+	private const string _cpmEnabled =
+		"<Project><PropertyGroup><ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally></PropertyGroup></Project>";
+
+	private const string _cpmOptOut =
+		"<Project><PropertyGroup><ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally></PropertyGroup></Project>";
+
+	private const string _projectWithInlineVersion =
+		"<Project><ItemGroup><PackageReference Include=\"Quartz\" Version=\"3.18.2\" /></ItemGroup></Project>";
+
+	[Fact]
+	public async Task CPM02_ShouldNotFlagAProjectThatOptsOutOfCentralPackageManagement()
+	{
+		var context = CreateContext(new Dictionary<string, string>
+		{
+			["Directory.Packages.props"] = _cpmEnabled,
+			["Worker.Jobs/Directory.Packages.props"] = _cpmOptOut,
+			["Worker.Jobs/Worker.Jobs.csproj"] = _projectWithInlineVersion
+		});
+
+		var result = await GetRule("CPM-02").EvaluateAsync(context, CancellationToken.None);
+
+		result.Passed.Should().BeTrue(
+			"the inline version is the project's only source of a version, so removing it breaks restore");
+	}
+
+	[Fact]
+	public async Task CPM02_ShouldStillFlagAProjectGovernedByCentralPackageManagement()
+	{
+		// Guards the exclusion above against over-reaching.
+		var context = CreateContext(new Dictionary<string, string>
+		{
+			["Directory.Packages.props"] = _cpmEnabled,
+			["Lib/Lib.csproj"] = _projectWithInlineVersion
+		});
+
+		var result = await GetRule("CPM-02").EvaluateAsync(context, CancellationToken.None);
+
+		result.Passed.Should().BeFalse();
+		result.Message.Should().Contain("Lib.csproj");
+	}
+
+	[Fact]
+	public async Task CPM02_ShouldFlagOnlyTheGovernedProject_InAMixedRepository()
+	{
+		var context = CreateContext(new Dictionary<string, string>
+		{
+			["Directory.Packages.props"] = _cpmEnabled,
+			["Worker.Jobs/Directory.Packages.props"] = _cpmOptOut,
+			["Worker.Jobs/Worker.Jobs.csproj"] = _projectWithInlineVersion,
+			["Lib/Lib.csproj"] = _projectWithInlineVersion
+		});
+
+		var result = await GetRule("CPM-02").EvaluateAsync(context, CancellationToken.None);
+
+		result.Passed.Should().BeFalse();
+		result.Message.Should().Contain("Lib.csproj");
+		result.Message.Should().NotContain("Worker.Jobs.csproj");
+	}
+
+	[Fact]
+	public async Task CPM02_ShouldLetTheNearestDirectoryPackagesPropsDecide()
+	{
+		// A nested opt-in under a repository-level opt-out is still governed: nearest wins, as MSBuild
+		// resolves it.
+		var context = CreateContext(new Dictionary<string, string>
+		{
+			["Directory.Packages.props"] = _cpmOptOut,
+			["Lib/Directory.Packages.props"] = _cpmEnabled,
+			["Lib/Lib.csproj"] = _projectWithInlineVersion
+		});
+
+		var result = await GetRule("CPM-02").EvaluateAsync(context, CancellationToken.None);
+
+		result.Passed.Should().BeFalse("the nearest Directory.Packages.props enables CPM");
+		result.Message.Should().Contain("Lib.csproj");
+	}
+
+	private static IRule GetRule(string ruleId)
+		=> RuleRegistry.Rules.First(r => r.RuleId == ruleId);
+
+	private static RepositoryContext CreateContext(Dictionary<string, string> files) => new()
+	{
+		FullName = "test-org/Acme.Suite",
+		Name = "Acme.Suite",
+		DefaultBranch = "main",
+		CurrentBranch = "main",
+		Options = new RepoOptions(),
+		FilePaths = [.. files.Keys],
+		FileContents = files
+	};
+}

--- a/PanoramicData.NugetManagement.Test/GlobalJsonRemediationTests.cs
+++ b/PanoramicData.NugetManagement.Test/GlobalJsonRemediationTests.cs
@@ -49,7 +49,7 @@ public class GlobalJsonRemediationTests(ITestOutputHelper output) : TestWithOutp
 		// repository had already configured — none of which this rule has an opinion on.
 		var context = CreateContext(
 			testProject: _xunitV3,
-			globalJson: """{"sdk":{"version":"10.0.100"},"msbuild-sdks":{"Contoso.Build":"1.2.3"}}""");
+			globalJson: """{"sdk":{"version":"9.0.100"},"msbuild-sdks":{"Contoso.Build":"1.2.3"}}""");
 
 		var result = await Rule("VER-03").EvaluateAsync(context, CancellationToken.None);
 
@@ -82,6 +82,44 @@ public class GlobalJsonRemediationTests(ITestOutputHelper output) : TestWithOutp
 		var result = await Rule("TST-06").EvaluateAsync(context, CancellationToken.None);
 
 		result.IsApplicable.Should().BeFalse();
+	}
+
+	[Fact]
+	public void VER03_ShouldPinTheFeatureBandFloor_NotTheMachinesNewestSdk()
+	{
+		// Issue 76: LatestDotNetSdkVersion is whatever the machine running this tool has installed.
+		// Pinning it makes one machine's install list a build requirement for every other machine,
+		// because rollForward never rolls down.
+		// Asserted on shape, not on a comparison with the detected SDK: on a machine whose newest
+		// band happens to be the floor the two legitimately coincide, and a test that fails there
+		// would be coupled to the host's install list - the very fault this fixes.
+		Standards.DotNetSdkPinVersion.Should().EndWith(".100");
+		Standards.DotNetSdkPinVersion.Should().StartWith(
+			string.Join('.', Standards.LatestDotNetSdkVersion.Split('.').Take(2)) + ".");
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void VER03_TemplateShouldRollForwardWithinTheMajor_NotWithinAFeatureBand(bool includeTestRunner)
+	{
+		var content = Standards.GetGlobalJsonContent(includeTestRunner);
+
+		content.Should().Contain("latestMinor");
+		content.Should().NotContain("latestFeature", "latestFeature cannot roll down to an installed band");
+		content.Should().Contain(Standards.DotNetSdkPinVersion);
+	}
+
+	[Fact]
+	public async Task VER03_ShouldPass_WhenGlobalJsonAlreadyPinsTheFloor()
+	{
+		var context = CreateContext(
+			testProject: _xunitV3,
+			globalJson: "{\"sdk\":{\"version\":\"" + Standards.DotNetSdkPinVersion + "\",\"rollForward\":\"latestMinor\"}}");
+
+		var result = await Rule("VER-03").EvaluateAsync(context, CancellationToken.None);
+
+		result.Passed.Should().BeTrue();
 	}
 
 	private static IRule Rule(string ruleId) => RuleRegistry.Rules.First(r => r.RuleId == ruleId);

--- a/PanoramicData.NugetManagement.Test/RuleEvaluationTests.cs
+++ b/PanoramicData.NugetManagement.Test/RuleEvaluationTests.cs
@@ -2121,7 +2121,7 @@ public class RuleEvaluationTests : TestWithOutput
 	{
 		var context = CreateContext(new Dictionary<string, string>
 		{
-			["global.json"] = $"{{\"sdk\":{{\"version\":\"{Standards.LatestDotNetSdkVersion}\",\"rollForward\":\"latestFeature\"}}}}"
+			["global.json"] = $"{{\"sdk\":{{\"version\":\"{Standards.DotNetSdkPinVersion}\",\"rollForward\":\"latestMinor\"}}}}"
 		});
 
 		var result = await GetRule("VER-03").EvaluateAsync(context, CancellationToken.None);
@@ -2142,7 +2142,7 @@ public class RuleEvaluationTests : TestWithOutput
 	{
 		var context = CreateContext(new Dictionary<string, string>
 		{
-			["global.json"] = "{\"sdk\":{\"version\":\"10.0.100\",\"rollForward\":\"latestFeature\"}}"
+			["global.json"] = "{\"sdk\":{\"version\":\"9.0.100\",\"rollForward\":\"latestFeature\"}}"
 		});
 
 		var result = await GetRule("VER-03").EvaluateAsync(context, CancellationToken.None);

--- a/PanoramicData.NugetManagement/Models/Standards.cs
+++ b/PanoramicData.NugetManagement/Models/Standards.cs
@@ -25,6 +25,26 @@ public static class Standards
 	public static string LatestDotNetSdkVersion => field ??= DetectLatestSdkVersion();
 
 	/// <summary>
+	/// The SDK version to pin in <c>global.json</c>: the feature-band floor for the target major
+	/// version, for example <c>10.0.100</c>.
+	/// </summary>
+	/// <remarks>
+	/// Deliberately NOT <see cref="LatestDotNetSdkVersion"/>. That is whatever the machine running
+	/// this tool happens to have installed, and pinning it makes one machine's install list a build
+	/// requirement for everyone else: a repository pinned to a 4xx band cannot run any dotnet command
+	/// on a machine whose newest band is 3xx, because rollForward never rolls down. The floor plus
+	/// <c>latestMinor</c> expresses "a .NET N SDK", which is what the pin is actually for.
+	/// </remarks>
+	public static string DotNetSdkPinVersion
+	{
+		get
+		{
+			var parts = LatestDotNetSdkVersion.Split('.');
+			return parts.Length >= 2 ? $"{parts[0]}.{parts[1]}.100" : LatestDotNetSdkVersion;
+		}
+	}
+
+	/// <summary>
 	/// Detects the latest installed .NET SDK version by running <c>dotnet --list-sdks</c>
 	/// and selecting the highest version that matches the current major version (10).
 	/// </summary>
@@ -255,8 +275,8 @@ public static class Standards
 			? $$"""
 				{
 				  "sdk": {
-					"version": "{{LatestDotNetSdkVersion}}",
-					"rollForward": "latestFeature"
+					"version": "{{DotNetSdkPinVersion}}",
+					"rollForward": "latestMinor"
 				  },
 				  "test": {
 					"runner": "{{MtpTestRunnerName}}"
@@ -266,8 +286,8 @@ public static class Standards
 			: $$"""
 				{
 				  "sdk": {
-					"version": "{{LatestDotNetSdkVersion}}",
-					"rollForward": "latestFeature"
+					"version": "{{DotNetSdkPinVersion}}",
+					"rollForward": "latestMinor"
 				  }
 				}
 				""";

--- a/PanoramicData.NugetManagement/Rules/CentralPackageManagement/CpmNoVersionInCsprojRule.cs
+++ b/PanoramicData.NugetManagement/Rules/CentralPackageManagement/CpmNoVersionInCsprojRule.cs
@@ -5,6 +5,12 @@ namespace PanoramicData.NugetManagement.Rules;
 
 /// <summary>
 /// Checks that .csproj files do not have Version= attributes on PackageReference elements.
+/// <para>
+/// Projects that opt out of central package management are excluded. CPM is resolved per
+/// directory, not per repository: a project whose nearest <c>Directory.Packages.props</c> sets
+/// <c>ManagePackageVersionsCentrally</c> to <c>false</c> gets its versions from the inline
+/// attributes and nowhere else, so removing them leaves it unable to restore (NU1015).
+/// </para>
 /// </summary>
 public partial class CpmNoVersionInCsprojRule : RuleBase
 {
@@ -37,10 +43,19 @@ public partial class CpmNoVersionInCsprojRule : RuleBase
 			}
 
 			// Check for PackageReference with Version= attribute (but not PackageVersion which is correct)
-			if (PackageReferenceVersionPattern().IsMatch(content))
+			if (!PackageReferenceVersionPattern().IsMatch(content))
 			{
-				violations.Add(csproj);
+				continue;
 			}
+
+			// An inline version is only a violation where CPM actually governs the project. Under an
+			// opt-out it is the sole source of the version, and removing it breaks restore.
+			if (OptsOutOfCentralPackageManagement(context, csproj))
+			{
+				continue;
+			}
+
+			violations.Add(csproj);
 		}
 
 		return Task.FromResult(violations.Count == 0
@@ -57,5 +72,42 @@ public partial class CpmNoVersionInCsprojRule : RuleBase
 						["projects"] = violations.ToArray()
 					}
 				}));
+	}
+
+	/// <summary>
+	/// Whether a project sits under an explicit central package management opt-out, resolved the way
+	/// MSBuild resolves the property: the nearest <c>Directory.Packages.props</c> at or above the
+	/// project's own directory decides, and nearer wins.
+	/// </summary>
+	/// <remarks>
+	/// Only an explicit <c>false</c> exempts a project. A repository with no
+	/// <c>Directory.Packages.props</c> at all is left to CPM-01, which is the rule that asks for one.
+	/// </remarks>
+	private static bool OptsOutOfCentralPackageManagement(RepositoryContext context, string csprojPath)
+	{
+		var directory = csprojPath.Replace(@"\", "/");
+		var lastSeparator = directory.LastIndexOf('/');
+		directory = lastSeparator < 0 ? string.Empty : directory[..lastSeparator];
+
+		while (true)
+		{
+			var candidate = directory.Length == 0
+				? "Directory.Packages.props"
+				: $"{directory}/Directory.Packages.props";
+
+			var props = context.GetFileContent(candidate);
+			if (props is not null)
+			{
+				return HasMsBuildProperty(props, "ManagePackageVersionsCentrally", "false");
+			}
+
+			if (directory.Length == 0)
+			{
+				return false;
+			}
+
+			var separator = directory.LastIndexOf('/');
+			directory = separator < 0 ? string.Empty : directory[..separator];
+		}
 	}
 }

--- a/PanoramicData.NugetManagement/Rules/Versioning/GlobalJsonRule.cs
+++ b/PanoramicData.NugetManagement/Rules/Versioning/GlobalJsonRule.cs
@@ -3,7 +3,12 @@ using PanoramicData.NugetManagement.Models;
 namespace PanoramicData.NugetManagement.Rules;
 
 /// <summary>
-/// Checks that global.json exists with the correct SDK version.
+/// Checks that global.json exists with an SDK pin.
+/// <para>
+/// The pin is the feature-band floor for the target major version, not the newest SDK on the
+/// machine running this tool. Pinning the latter makes one machine's install list a build
+/// requirement for every other machine, and <c>rollForward</c> never rolls down.
+/// </para>
 /// </summary>
 public class GlobalJsonRule : RuleBase
 {
@@ -34,35 +39,35 @@ public class GlobalJsonRule : RuleBase
 				"global.json not found at repository root.",
 				new RuleAdvisory
 				{
-					Summary = $"Create global.json pinning SDK version to {Standards.LatestDotNetSdkVersion} with rollForward: latestFeature.",
-					Detail = $"No `global.json` file was found at the repository root. Create one pinning the SDK version to `{Standards.LatestDotNetSdkVersion}` with `rollForward: latestFeature`.",
+					Summary = $"Create global.json pinning SDK version to {Standards.DotNetSdkPinVersion} with rollForward: latestMinor.",
+					Detail = $"No `global.json` file was found at the repository root. Create one pinning the SDK version to `{Standards.DotNetSdkPinVersion}` with `rollForward: latestMinor`.",
 					Data = new()
 					{
 						["expected_path"] = "global.json",
-						["latest_sdk"] = Standards.LatestDotNetSdkVersion,
+						["latest_sdk"] = Standards.DotNetSdkPinVersion,
 						["template_content"] = Standards.GetGlobalJsonContent(includeTestRunner)
 					}
 				}));
 		}
 
-		return Task.FromResult(Contains(content, Standards.LatestDotNetSdkVersion)
-			? Pass($"global.json found with SDK version {Standards.LatestDotNetSdkVersion}.")
+		return Task.FromResult(Contains(content, Standards.DotNetSdkPinVersion)
+			? Pass($"global.json found with SDK version {Standards.DotNetSdkPinVersion}.")
 			: Fail(
-				$"global.json does not reference SDK version {Standards.LatestDotNetSdkVersion}.",
+				$"global.json does not reference SDK version {Standards.DotNetSdkPinVersion}.",
 				new RuleAdvisory
 				{
-					Summary = $"Update the sdk.version in global.json to {Standards.LatestDotNetSdkVersion}.",
-					Detail = $"The `global.json` file does not reference SDK version `{Standards.LatestDotNetSdkVersion}`. Update the `sdk.version` property.",
+					Summary = $"Update the sdk.version in global.json to {Standards.DotNetSdkPinVersion}.",
+					Detail = $"The `global.json` file does not reference SDK version `{Standards.DotNetSdkPinVersion}`. Update the `sdk.version` property.",
 					Data = new()
 					{
 						["file"] = "global.json",
-						["latest_sdk"] = Standards.LatestDotNetSdkVersion,
+						["latest_sdk"] = Standards.DotNetSdkPinVersion,
 						// Sets the one property rather than rewriting the file. Replacing it wholesale
 						// discarded whatever else the repository kept there — msbuild-sdks, a test runner
 						// it had already configured — none of which this rule has an opinion on.
 						["remediation_type"] = "ensure_json_property",
 						["property_path"] = "sdk.version",
-						["property_value"] = Standards.LatestDotNetSdkVersion
+						["property_value"] = Standards.DotNetSdkPinVersion
 					}
 				}));
 	}

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-	"version": "10.0.400",
-	"rollForward": "latestFeature"
+	"version": "10.0.100",
+	"rollForward": "latestMinor"
   },
   "test": {
 	"runner": "Microsoft.Testing.Platform"


### PR DESCRIPTION
Fixes #75. Fixes #76.

Two rule-scoping defects, each of which could break a repository outright.

## CPM-02 — respect per-directory opt-outs (#75)

`CpmNoVersionInCsprojRule` flagged **every** `.csproj` with an inline `Version=`, without checking whether central package management governs that project. CPM is resolved *per directory*: a project whose nearest `Directory.Packages.props` sets `ManagePackageVersionsCentrally` to `false` takes its versions from those inline attributes **and nowhere else**. Removing them is not a tidy-up — it leaves the project unable to restore at all (`NU1015`).

The rule now walks up from the project's own directory to find the nearest `Directory.Packages.props`, as MSBuild does, and skips the project when that file is an explicit opt-out.

Deliberately narrow: **only an explicit `false` exempts a project.** A repository with no `Directory.Packages.props` at all is still left to CPM-01, which is the rule that asks for one — so this doesn't quietly stop asking repositories to adopt CPM.

## VER-03 — pin the band floor, not this machine's SDK (#76)

`GlobalJsonRule` pinned `Standards.LatestDotNetSdkVersion` — the newest SDK on whichever machine ran the tool — with `rollForward: latestFeature`. `latestFeature` never rolls **down**, so a repository pinned to a `4xx` band cannot run *any* `dotnet` command on a machine whose newest band is `3xx`. The value was also unstable: installing a newer SDK on one machine re-flagged and re-pinned every repository.

The pin is now `Standards.DotNetSdkPinVersion` — the feature-band floor for the target major, e.g. `10.0.100` — written with `rollForward: latestMinor`. That expresses *"a .NET N SDK"*, which is what the pin is for, without making one machine's install list a build requirement for everyone else.

**This repository's own `global.json` carried the identical `10.0.400` / `latestFeature` pin and is updated to match.** `SelfAssessmentTests` flagged it as soon as the rule was corrected — the fix demonstrating itself. It also means the repo no longer requires one specific SDK band to build, which was blocking people.

## Tests

Seven added — four for CPM-02, three for VER-03 — **all verified red before green**:

| Reverted | Failing tests |
|---|---|
| CPM-02 only | `ShouldNotFlagAProjectThatOptsOutOfCentralPackageManagement`, `ShouldFlagOnlyTheGovernedProject_InAMixedRepository` |
| VER-03 only | `TemplateShouldRollForwardWithinTheMajor_NotWithinAFeatureBand`, `ShouldPass_WhenGlobalJsonAlreadyPinsTheFloor` |

The over-correction guards (`ShouldStillFlagAProjectGovernedByCentralPackageManagement`, `ShouldLetTheNearestDirectoryPackagesPropsDecide`) pass in **both** states by design, so an exclusion cannot silently swallow real findings.

One assertion was deliberately written on shape rather than comparing against the detected SDK: on a machine whose newest band *is* the floor, the two legitimately coincide, and a test failing there would be coupled to the host's install list — the very fault being fixed.

## Two silent inversions caught

Two existing fixtures used `10.0.100` to represent a **wrong** pin. That is now the **correct** value, so both tests would have inverted meaning while still appearing to assert something. Both moved to `9.0.100`, preserving each test's original intent.

## Results

- Solution builds, **0 errors**, no new warnings (the one existing warning is `.Web` reporting pack-on-build cannot package a non-packable project, and predates this).
- Full suite **282 of 285**. The 3 failures are `GitHubIntegrationTests` reporting `GitHub:Token is not configured in user secrets` on a host without that secret, and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
